### PR TITLE
Add note about enabling permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Enable USB Debugging on your treadmill
     treadmill. Once rebooted, proceed to login to iFit. At this point,
     QZ Companion is running in the background and is ready to transmit
     treadmill speed and incline data to QZ.
+    
+    If it reads all 0's, try going to the treadmill's Settings > Apps > QZ Companion app > Permissions, and enabling all permissions.
 
 ![](media/image3.png)
 


### PR DESCRIPTION
For my Proform Pro 2000 I had to enable permissions for Storage to have data sent to QZ.
This change adds a note below the Companion app install which calls this out.