### PR TITLE
Add MacOS installation script

### DIFF
--- a/InstallPackage/QZ-Companion-MacOS
+++ b/InstallPackage/QZ-Companion-MacOS
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# QZ-Companion MacOS App Installer
+# Author: Jacob Senitza
+# Revised: January 5, 2024
+# QZ on Facebook - https://www.facebook.com/groups/149984563348738
+
+cd -- "$(dirname "$0")" || exit
+
+echo -e "\n*** Make sure your treadmill is powered-up and USB Debugging is turned on ***\n"
+
+read -r -p "Enter treadmill IP address: " TMIP
+
+echo "Log generated at $(date) for IP $TMIP" > QZ-Companion-log.txt
+
+echo | tee -a QZ-Companion-log.txt
+echo "Pinging $TMIP ..." | tee -a QZ-Companion-log.txt
+ping -c 1 "$TMIP" >> QZ-Companion-log.txt 2>&1
+if ping -c 1 "$TMIP" | grep -q '[0-9] *ms'; then
+  echo "Ping successful."
+else
+  echo "Cannot ping $TMIP."
+  exit 1
+fi
+sleep 5
+
+echo | tee -a QZ-Companion-log.txt
+echo "Connecting to treadmill via ADB ..." | tee -a QZ-Companion-log.txt
+echo >> QZ-Companion-log.txt
+
+# fix for 'failed to authenticate to {IP:port}'
+{
+  ./adb disconnect
+  ./adb kill-server
+  ./adb connect "$TMIP"
+} > /dev/null 2>&1
+
+{
+  ./adb disconnect
+  ./adb kill-server
+  ./adb connect "$TMIP"
+} >> QZ-Companion-log.txt 2>&1
+
+if ./adb connect "$TMIP" | grep -q 'connected to'; then
+  echo -e "ADB connection successful.\n"
+else
+  echo "Cannot establish ADB connection."
+  exit 1
+fi
+echo >> QZ-Companion-log.txt
+./adb devices -l >> QZ-Companion-log.txt
+sleep 5
+
+# report Android and SDK version
+{
+  echo "Android version:"
+  ./adb shell getprop ro.build.version.release
+  echo "SDK version:"
+  ./adb shell getprop ro.build.version.sdk
+  echo
+} >> QZ-Companion-log.txt
+
+echo -e  "Checking for previous installation ..." | tee -a QZ-Companion-log.txt
+if ./adb shell pidof org.cagnulein.qzcompanionnordictracktreadmill | grep -q '[0-9]*'; then
+  echo -e "QZ Companion found - removing\n" | tee -a QZ-Companion-log.txt
+  ./adb uninstall org.cagnulein.qzcompanionnordictracktreadmill >> QZ-Companion-log.txt 2>&1
+else
+  echo -e "QZ Companion not installed\n" | tee -a QZ-Companion-log.txt
+fi
+sleep 5
+
+echo -e "Installing QZ Companion ..." | tee -a QZ-Companion-log.txt
+ ./adb install QZCompanionNordictrackTreadmill.apk 2>&1 | tee -a QZ-Companion-log.txt
+sleep 5
+
+echo -e "Launching QZ Companion ...\n" | tee -a QZ-Companion-log.txt
+./adb shell monkey -p org.cagnulein.qzcompanionnordictracktreadmill 1 >> QZ-Companion-log.txt 2>&1
+sleep 5
+
+echo -e "Launching iFit ...\n" | tee -a QZ-Companion-log.txt
+./adb shell monkey -p com.ifit.standalone 1 >> QZ-Companion-log.txt 2>&1
+sleep 5
+
+# save debug files and permanently enable privileged mode
+./adb shell mkdir -p /sdcard/.wolfDev/keepme > /dev/null 2>&1
+./adb shell dumpsys package org.cagnulein.qzcompanionnordictracktreadmill > dumpsys.log 2>&1
+./adb logcat -d > logcat.txt 2>&1
+
+./adb shell pm grant org.cagnulein.qzcompanionnordictracktreadmill android.permission.READ_LOGS
+
+read -n 1 -r -p "QZ Companion is installed. Press any key to reboot treadmill . . ."
+echo -e "\nRebooting treadmill ..." | tee -a QZ-Companion-log.txt
+
+./adb reboot
+
+echo -e "\nInstallation complete.\nRefer to QZ-Companion-log.txt for installation details."

--- a/README.md
+++ b/README.md
@@ -126,24 +126,36 @@ and know your treadmills IP, you can skip to step 4.
 with medium confidence](media/image2.png)
     Enable USB Debugging on your treadmill
 
-**QZ Companion Installation Method 1:  Over Wifi via an ADB script run from a Windows PC. Choose this method if you can successfully establish an ADB connection between treadmill and Windows PC.**
+**QZ Companion Installation Method 1:  Over Wifi via an ADB script run from a Windows PC or Mac. Choose this method if you can successfully establish an ADB connection between treadmill and Windows PC.**
 
 4.  Install the QZ Companion app on your treadmill. Download the QZ
     Companion installation package from this Github repository and extract
-    it to your Windows PC. Go into the extracted folder and run
-    qz-companion.bat by either double-clicking it or running it from the
-    command-line. When prompted to enter the treadmills IP address,
+    it to your computer. 
+
+    **If you are using a Windows PC:**
+    Go into the extracted folder, open the folder InstallPackage and
+    run `qz-companion.bat` by either double-clicking it or running it from the
+    command-line. 
+
+    **If you are using a Mac:**
+    Go into the extracted folder and open the folder InstallPackage.
+    Right click the file `QZ-Companion-MacOS` and select open **OR** navigate
+    to this folder in Terminal and enter `./QZ-Companion-MacOS`
+        _Important note: Double clicking this file will cause MacOS to throw
+        a security warning, you must use one of the methods above._
+
+    When prompted to enter the treadmills IP address,
     enter the same IP as noted in previous Step 3 and hit enter. The
     script will ping the IP address first to ensure it is reachable on
     the network, then proceed to open an ADB connection and install the
-    QZ Companion app. When completed, the script will reboot the
-    treadmill. 
+    QZ Companion app. When completed, the script will prompt you to 
+    press any key to reboot the treadmill. 
     
     Once rebooted, you will have iFit running in the foreground and QZ Companion running 
     in the background. You need to bring QZ Companion to the foreground for a one-time setup. You should still have access 
     to the Android system by swiping up from the bottom of the screen to see the Android navigation bar. If you don't see 
-    the navigation bar, you will need to enable Privileged mode again (see Step #2 above), however Privileged mode should be permanately enabled as part on the 
-    qz-companion.bat installation script. The Android navigation bar displays 3 navigation controls: Back, Home, and App Overview. 
+    the navigation bar, you will need to enable Privileged mode again (see Step #2 above), however Privileged mode should be permanently enabled as part of the
+    `QZ-Companion.bat` or `QZ-Companion-MacOS` installation script. The Android navigation bar displays 3 navigation controls: Back, Home, and App Overview. 
     Hit the App Overview button and swipe over to QZ Companion. In the QZ Companion screen, select your specific exercise machine (e.g. "NordicTrack C2950").
     Once again, swipe up from the bottom of the screen to display the Android navigation bar, select App Overview, and swipe over to iFit. Note that in 
     some cases, you may need to reboot your exercise machine once more for the QZ Companion selection to work.
@@ -155,7 +167,7 @@ with medium confidence](media/image2.png)
     If it reads all 0's, try going to the treadmill's Settings > Apps > QZ Companion app > Permissions, and enabling all permissions.
 
 ![](media/image3.png)
-    Run QZ-Companion.bat on a Wifi connected Windows PC
+    Run `QZ-Companion.bat` or `QZ-Companion-MacOS` script on a WiFi connected computer
 
 **QZ Installation Method 2: Via the treadmill build-in web browser.**
 
@@ -185,8 +197,8 @@ QZ Companion will proceed to install. You will get a confirmation screen when do
 -   When completed, you should reboot the treadmill by cycling the power switch. Once rebooted, you will have iFit running in the foreground and QZ Companion running 
     in the background. You need to bring QZ Companion to the foreground for a one-time setup. You should still have access 
     to the Android system by swiping up from the bottom of the screen to see the Android navigation bar. If you don't see 
-    the navigation bar, you will need to enable Privileged mode again (see Step #2 above), however Privileged mode should be permanately enabled as part on the 
-    qz-companion.bat installation script. The Android navigation bar displays 3 navigation controls: Back, Home, and App Overview. 
+    the navigation bar, you will need to enable Privileged mode again (see Step #2 above), however Privileged mode should be permanently enabled as part of the 
+    `QZ-Companion.bat` or `QZ-Companion-MacOS` installation script. The Android navigation bar displays 3 navigation controls: Back, Home, and App Overview. 
     Hit the App Overview button and swipe over to QZ Companion. In the QZ Companion screen, select your specific exercise machine (e.g. "NordicTrack C2950").
     Once again, swipe up from the bottom of the screen to display the Android navigation bar, select App Overview, and swipe over to iFit. Note that in 
     some cases, you may need to reboot your exercise machine once more for the QZ Companion selection to work.
@@ -252,19 +264,22 @@ generated](media/image6.png)
 
 **The QZ Companion installation package (qz-companion.zip) contains**:
 
--   QZCompanionNordictrackTreadmill.apk (QZ Companion Android app).
+-   `QZCompanionNordictrackTreadmill.apk` (QZ Companion Android app).
 
--   QZ-Companion.bat (batch script used to install QZ Companion via
-    ADB).
+-   `QZ-Companion.bat` (batch script used to install QZ Companion via
+    ADB on Windows).
 
--   QZ-Companion-simple.bat (alternative batch script to use if you wish
+-   `QZ-Companion-MacOS` (shell script used to install QZ Companion via
+    ADB on MacOS).
+
+-   `QZ-Companion-simple.bat` (alternative batch script to use if you wish
     to run the commands separately for debugging and troubleshooting
     purposes).
 
--   Uninstall-QZ-Companion.bat (batch script used to uninstall/remove QZ
+-   `Uninstall-QZ-Companion.bat` (batch script used to uninstall/remove QZ
     Companion).
 
--   All other files (adb.exe, AdbWinApi.dll, AdbWinUsbApi.dll, tee.exe) are required for the scripts. Do not delete them.
+-   All other files (`adb.exe`, `AdbWinApi.dll`, `AdbWinUsbApi.dll`, `tee.exe`) are required for the scripts. Do not delete them.
 
 **Troubleshooting**:
 


### PR DESCRIPTION
Adds shell support for MacOS installation of the QZCompanion. Instructions have been altered in the README.md to support this new script.

I've also included the adb executable from https://developer.android.com/tools/releases/platform-tools for MacOS similar to the current implementation using `adb.exe` for the `QZ-Companion.bat` script.

I've tested this quite a bit using 2 different macs on my 2021 NordicTrack 2950 and everything seems to work as expected. 