### PR TITLE
Change X9i to use MainActivity.sendCommand() instead of shellRuntime.exec()

### DIFF
--- a/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/MainActivity.java
+++ b/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/MainActivity.java
@@ -288,6 +288,10 @@ public class MainActivity extends AppCompatActivity  implements DeviceConnection
                 } else if(i == R.id.x14i) {
                     UDPListenerService.setDevice(UDPListenerService._device.x14i);
                 } else if(i == R.id.x9i) {
+                    if (!isAccessibilityServiceEnabled(getApplicationContext(), MyAccessibilityService.class)) {
+                        Intent intent = new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS);
+                        startActivity(intent);
+                    }
                     UDPListenerService.setDevice(UDPListenerService._device.x9i);
 				} else if(i == R.id.t85s) {
                     UDPListenerService.setDevice(UDPListenerService._device.t85s);
@@ -391,7 +395,7 @@ public class MainActivity extends AppCompatActivity  implements DeviceConnection
             public void onClick(View view) {
                 int device = sharedPreferences.getInt("device", R.id.other);
                 // test
-                if(device == R.id.x22i_noadb || device == R.id.t95s)
+                if(device == R.id.x22i_noadb || device == R.id.t95s || device == R.id.x9i)
                     MyAccessibilityService.performSwipe(600, 600, 300, 400, 100);
 
 

--- a/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/MainActivity.java
+++ b/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/MainActivity.java
@@ -117,7 +117,9 @@ public class MainActivity extends AppCompatActivity  implements DeviceConnection
 
     @Override
     public void receivedData(DeviceConnection devConn, byte[] data, int offset, int length) {
-        Log.i(LOG_TAG, data.toString());
+        String dataStr = new String(data, offset, length);
+        Log.i(LOG_TAG, "ADB Received: " + dataStr);
+        QZService.sendBroadcast("ADB Received: " + dataStr);
     }
 
     @Override
@@ -523,6 +525,8 @@ public class MainActivity extends AppCompatActivity  implements DeviceConnection
 
     static public void sendCommand(String command) {
         if(ADBConnected) {
+            Log.i(LOG_TAG, "Queueing command: " + command);
+            QZService.sendBroadcast("ADB Queueing: " + command);
             StringBuilder commandBuffer = new StringBuilder();
 
             commandBuffer.append(command);

--- a/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
+++ b/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
@@ -627,7 +627,7 @@ public class UDPListenerService extends Service {
                             MyAccessibilityService.performSwipe(x1, y1Speed, x1, y2, 200);
                         } else {
                             String command = "input swipe " + x1 + " " + y1Speed + " " + x1 + " " + y2 + " 200";
-                            if (device == _device.x22i || device == _device.x14i || device == _device.x9i) {
+                            if (device == _device.x22i || device == _device.x14i) {
                                 shellRuntime.exec(command);
                             } else {
                                 MainActivity.sendCommand(command);
@@ -795,7 +795,7 @@ public class UDPListenerService extends Service {
                         MyAccessibilityService.performSwipe(x1, y1Inclination, x1, y2, 200);
                     } else {
                         String command = " input swipe " + x1 + " " + y1Inclination + " " + x1 + " " + y2 + " 200";
-                        if (device == _device.x22i || device == _device.x14i || device == _device.x9i || device == _device.s22i_NTEX02117_2) {
+                        if (device == _device.x22i || device == _device.x14i || device == _device.s22i_NTEX02117_2) {
                             shellRuntime.exec(command);
                         } else {
                             MainActivity.sendCommand(command);

--- a/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
+++ b/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
@@ -373,11 +373,20 @@ public class UDPListenerService extends Service {
 
                         String command = "input swipe " + x1 + " " + y1Resistance + " " + x1 + " " + y2 + " 200";
                         if (device == _device.s22i_NTEX02117_2) {
-                            shellRuntime.exec(command);
+                            try {
+                                shellRuntime.exec(command);
+                                writeLog("[RESISTANCE] shellRuntime.exec: " + command);
+                            } catch (Exception e) {
+                                writeLog("[RESISTANCE] shellRuntime.exec FAILED: " + e.getMessage());
+                            }
                         } else {
-                            MainActivity.sendCommand(command);
+                            try {
+                                MainActivity.sendCommand(command);
+                                writeLog("[RESISTANCE] MainActivity.sendCommand: " + command);
+                            } catch (Exception e) {
+                                writeLog("[RESISTANCE] MainActivity.sendCommand FAILED: " + e.getMessage());
+                            }
                         }
-                        writeLog(command);
 
 						if (device == _device.proform_carbon_e7 || device == _device.proform_carbon_c10 || device == _device.s15i || device == _device.s22i || device == _device.s27i || device == _device.s22i_NTEX02121_5 || device == _device.s22i_NTEX02117_2 || device == _device.tdf10 || device == _device.tdf10_inclination || device == _device.proform_studio_bike_pro22 || device == _device.NTEX71021 || device == _device.se9i_elliptical)
                             y1Resistance = y2;  //set new vertical position of incline slider
@@ -449,11 +458,20 @@ public class UDPListenerService extends Service {
                         if (skip == false) {
                             String command = "input swipe " + x1 + " " + y1Resistance + " " + x1 + " " + y2 + " 200";
                             if (device == _device.s22i_NTEX02117_2) {
-                                shellRuntime.exec(command);
+                                try {
+                                    shellRuntime.exec(command);
+                                    writeLog("[BIKE_RESISTANCE] shellRuntime.exec: " + command);
+                                } catch (Exception e) {
+                                    writeLog("[BIKE_RESISTANCE] shellRuntime.exec FAILED: " + e.getMessage());
+                                }
                             } else {
-                                MainActivity.sendCommand(command);
+                                try {
+                                    MainActivity.sendCommand(command);
+                                    writeLog("[BIKE_RESISTANCE] MainActivity.sendCommand: " + command);
+                                } catch (Exception e) {
+                                    writeLog("[BIKE_RESISTANCE] MainActivity.sendCommand FAILED: " + e.getMessage());
+                                }
                             }
-                            writeLog(command);
                             y1Resistance = y2;  //set new vertical position of resistance slider - Added
                             lastReqResistance = reqResistance;
                             lastSwipeMs = Calendar.getInstance().getTimeInMillis();
@@ -625,14 +643,24 @@ public class UDPListenerService extends Service {
 
                         if (device == _device.x22i_noadb || device == _device.t95s) {
                             MyAccessibilityService.performSwipe(x1, y1Speed, x1, y2, 200);
+                            writeLog("[TREADMILL_SPEED] AccessibilityService.performSwipe: (" + x1 + " " + y1Speed + " -> " + x1 + " " + y2 + ")");
                         } else {
                             String command = "input swipe " + x1 + " " + y1Speed + " " + x1 + " " + y2 + " 200";
                             if (device == _device.x22i || device == _device.x14i) {
-                                shellRuntime.exec(command);
+                                try {
+                                    shellRuntime.exec(command);
+                                    writeLog("[TREADMILL_SPEED] shellRuntime.exec: " + command);
+                                } catch (Exception e) {
+                                    writeLog("[TREADMILL_SPEED] shellRuntime.exec FAILED: " + e.getMessage());
+                                }
                             } else {
-                                MainActivity.sendCommand(command);
+                                try {
+                                    MainActivity.sendCommand(command);
+                                    writeLog("[TREADMILL_SPEED] MainActivity.sendCommand: " + command);
+                                } catch (Exception e) {
+                                    writeLog("[TREADMILL_SPEED] MainActivity.sendCommand FAILED: " + e.getMessage());
+                                }
                             }
-                            writeLog(command);
                         }
 
                         if (device == _device.x11i || device == _device.proform_carbon_t14 || device == _device.nordictrack_2450 || device == _device.x14i || device == _device.x9i || device == _device.x22i || device == _device.x22i_v2 || device == _device.x22i_noadb || device == _device.elite1000 || device == _device.proform_pro_2000 || device == _device.c1750 || device == _device.c1750_2021 || device == _device.c1750_2020 || device == _device.c1750_2020_kph || device == _device.proform_2000 || device == _device.proform_pro_9000 || device == _device.t85s || device == _device.t95s || device == _device.t65s || device == _device.grand_tour_pro || device == _device.t75s || device == _device.s40 || device == _device.exp7i || device == _device.x32i || device == _device.x32i_NTL39019 || device == _device.x32i_NTL39221)
@@ -793,14 +821,24 @@ public class UDPListenerService extends Service {
 
                     if (device == _device.x22i_noadb || device == _device.t95s) {
                         MyAccessibilityService.performSwipe(x1, y1Inclination, x1, y2, 200);
+                        writeLog("[TREADMILL_INCLINE] AccessibilityService.performSwipe: (" + x1 + " " + y1Inclination + " -> " + x1 + " " + y2 + ")");
                     } else {
-                        String command = " input swipe " + x1 + " " + y1Inclination + " " + x1 + " " + y2 + " 200";
+                        String command = "input swipe " + x1 + " " + y1Inclination + " " + x1 + " " + y2 + " 200";
                         if (device == _device.x22i || device == _device.x14i || device == _device.s22i_NTEX02117_2) {
-                            shellRuntime.exec(command);
+                            try {
+                                shellRuntime.exec(command);
+                                writeLog("[TREADMILL_INCLINE] shellRuntime.exec: " + command);
+                            } catch (Exception e) {
+                                writeLog("[TREADMILL_INCLINE] shellRuntime.exec FAILED: " + e.getMessage());
+                            }
                         } else {
-                            MainActivity.sendCommand(command);
+                            try {
+                                MainActivity.sendCommand(command);
+                                writeLog("[TREADMILL_INCLINE] MainActivity.sendCommand: " + command);
+                            } catch (Exception e) {
+                                writeLog("[TREADMILL_INCLINE] MainActivity.sendCommand FAILED: " + e.getMessage());
+                            }
                         }
-                        writeLog(command);
                     }
 
                     if (device == _device.x11i || device == _device.nordictrack_2450 || device == _device.elite1000 || device == _device.proform_pro_2000 || device == _device.x22i || device == _device.x22i_v2 || device == _device.x22i_noadb || device == _device.x14i || device == _device.x9i || device == _device.c1750 || device == _device.c1750_2021 || device == _device.c1750_2020  || device == _device.c1750_2020_kph || device == _device.proform_2000 || device == _device.proform_pro_9000 || device == _device.t85s  || device == _device.t95s || device == _device.t65s || device == _device.t75s || device == _device.grand_tour_pro || device == _device.s40 || device == _device.exp7i || device == _device.x32i || device == _device.x32i_NTL39221)

--- a/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
+++ b/app/src/main/java/org/cagnulein/qzcompanionnordictracktreadmill/UDPListenerService.java
@@ -641,7 +641,7 @@ public class UDPListenerService extends Service {
                             y2 = (int) ((-19.921 * reqSpeed) + 631.03);
                         }
 
-                        if (device == _device.x22i_noadb || device == _device.t95s) {
+                        if (device == _device.x22i_noadb || device == _device.t95s || device == _device.x9i) {
                             MyAccessibilityService.performSwipe(x1, y1Speed, x1, y2, 200);
                             writeLog("[TREADMILL_SPEED] AccessibilityService.performSwipe: (" + x1 + " " + y1Speed + " -> " + x1 + " " + y2 + ")");
                         } else {
@@ -819,7 +819,7 @@ public class UDPListenerService extends Service {
                         y2 = (int) ((-21.804 * reqInclination) + 520.11);
                     }
 
-                    if (device == _device.x22i_noadb || device == _device.t95s) {
+                    if (device == _device.x22i_noadb || device == _device.t95s || device == _device.x9i) {
                         MyAccessibilityService.performSwipe(x1, y1Inclination, x1, y2, 200);
                         writeLog("[TREADMILL_INCLINE] AccessibilityService.performSwipe: (" + x1 + " " + y1Inclination + " -> " + x1 + " " + y2 + ")");
                     } else {


### PR DESCRIPTION
Updated command execution for X9i device to use ADB connection method
(MainActivity.sendCommand) instead of direct shell execution (shellRuntime.exec).
This aligns X9i with the standard device implementation pattern.

Changes:
- Speed control: X9i now uses MainActivity.sendCommand()
- Inclination control: X9i now uses MainActivity.sendCommand()